### PR TITLE
Support closures for exists and current version #2

### DIFF
--- a/src/v1/ExtensionLoader.php
+++ b/src/v1/ExtensionLoader.php
@@ -14,6 +14,8 @@ namespace EDD\ExtensionUtils\v1;
 
 class ExtensionLoader {
 
+	const VERSION = '1.0.1';
+
 	/**
 	 * @var string Path to the plugin file.
 	 */
@@ -37,9 +39,9 @@ class ExtensionLoader {
 	/**
 	 * Constructor.
 	 *
-	 * @param string $pluginFile   Path to the plugin file ( __FILE__ from main plugin file.)
-	 * @param \Closure|\Callable|mixed Callback to execute if requirements are met.
-	 * @param array  $requirements Requirements to pass to the checker class.
+	 * @param string                   $pluginFile   Path to the plugin file ( __FILE__ from main plugin file.)
+	 * @param \Closure|\Callable|mixed $callback     Callback to execute if requirements are met.
+	 * @param array                    $requirements Requirements to pass to the checker class.
 	 *
 	 * @throws \InvalidArgumentException
 	 */

--- a/src/v1/RequirementsChecker.php
+++ b/src/v1/RequirementsChecker.php
@@ -130,7 +130,12 @@ class RequirementsChecker {
 					$exists  = defined( 'EDD_VERSION' );
 					break;
 				default:
-					$version = false;
+					$version = isset( $properties['current'] ) ? $properties['current'] : false;
+					$exists  = isset( $properties['exists'] ) ? $properties['exists'] : false;
+
+					if ( is_callable( $exists ) ) {
+						$exists = call_user_func( $exists );
+					}
 					break;
 			}
 
@@ -138,11 +143,33 @@ class RequirementsChecker {
 				$this->requirements[ $requirement_id ] = array_merge( $this->requirements[ $requirement_id ], array(
 					'current' => $version,
 					'checked' => true,
-					'met'     => version_compare( $version, $properties['minimum'], '>=' ),
-					'exists'  => isset( $exists ) ? $exists : $this->requirements[ $requirement_id ]['exists']
+					'met'     => $this->minimumVersionMet( $version, $properties['minimum'] ),
+					'exists'  => (bool) $exists,
 				) );
 			}
 		}
+	}
+
+	/**
+	 * Determines if the minimum version has been met.
+	 *
+	 * @since 1.0.1
+	 *
+	 * @param string|\Closure $currentVersion
+	 * @param string          $minimumVersion
+	 *
+	 * @return bool
+	 */
+	private function minimumVersionMet( $currentVersion, $minimumVersion ) {
+		if ( is_callable( $currentVersion ) ) {
+			$currentVersion = call_user_func( $currentVersion );
+		}
+
+		if ( ! is_string( $currentVersion ) ) {
+			return false;
+		}
+
+		return version_compare( $currentVersion, $minimumVersion, '>=' );
 	}
 
 	/**

--- a/src/v1/RequirementsChecker.php
+++ b/src/v1/RequirementsChecker.php
@@ -221,7 +221,7 @@ class RequirementsChecker {
 	 */
 	private function unmetRequirementDescription( $requirement ) {
 		// Requirement exists, but is out of date.
-		if ( $this->parseRequirementProperty( $requirement, 'exists' ) ) {
+		if ( $this->parseRequirementProperty( $requirement, 'exists' ) && $this->parseRequirementProperty( $requirement, 'current' ) ) {
 			return sprintf(
 				$this->unmetRequirementsDescriptionText(),
 				'<strong>' . esc_html( $this->parseRequirementProperty( $requirement, 'name' ) ) . '</strong>',


### PR DESCRIPTION
Closes #2 

1. Adds a version constant to the `ExtensionLoader`.
2. Fix constructor docblocks.
3. Support passing closures for requirement `'current'` and `'exists'` args. That allows them to be evaluated on `plugins_loaded` instead of when they're defined.

## Sample implementation

```php
$requirements = array(
	'php'                    => '5.3',
	'easy-digital-downloads' => '2.9',
	'mailpoet'               => array(
		'minimum' => '2.0',
		'name'    => 'MailPoet',
		'exists'  => static function () {
			return defined( 'MAILPOET_VERSION' );
		},
		'current' => static function () {
			return defined( 'MAILPOET_VERSION' ) ? MAILPOET_VERSION : false;
		},
	),
);
```

See https://github.com/awesomemotive/edd-mailpoet/pull/40 for full implementation.